### PR TITLE
Some improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ hashbrown = "0.11.2"
 iced-x86 = { version = "1.12.0", default-features = false, features = ["std", "decoder", "instr_info", "op_code_info"] }
 object = "0.25.3"
 structopt = "0.3.21"
+memmap = "0.7.0"
 
 [profile.release]
 codegen-units = 1 


### PR DESCRIPTION
- Use Context::with_context instead of Context::context to avoid
  unnecessary allocations in the case that there is no error
- Make `should_ignore_cpuid` a `const fn`
- Use memory mapped IO, which increases performance slightly. This also
  causes opening /dev/zero or /dev/null to now return an error
  immediately rather than hang.